### PR TITLE
Fixed minibadge message collision

### DIFF
--- a/Saintcon2021/Saintcon2021/Scenes/menuScene.c
+++ b/Saintcon2021/Saintcon2021/Scenes/menuScene.c
@@ -176,7 +176,7 @@ Scene menu_scene_loop(bool init) {
 			return menu_selected;
 		menu_scrolling = false;
 	}
-	if (true) {
+	if (now > minibadge_delay) {
 		if (menu_check_minibadge(minibadge_addr++))
 			if (newUnlock(UNLOCK_MINI))
 				return REWARD;


### PR DESCRIPTION
This addresses Issue #2 by giving each minibadge that attempts to display a message adequate time to have the message displayed before moving on to the next minibadge (by i2c address). 